### PR TITLE
1.10

### DIFF
--- a/CC_Inventory_V1.ps1
+++ b/CC_Inventory_V1.ps1
@@ -85,6 +85,236 @@
 .PARAMETER HTML
 	Creates an HTML file with an.html extension.
 	This parameter is set True if no other output format is selected.
+.PARAMETER Text
+	Creates a formatted text file with a.txt extension.
+	This parameter is disabled by default.
+.PARAMETER ProfileName
+	The profile name to use for Get-XDAuthentication.
+	
+	The name associated with a set of credentials in the local store that are to be 
+	read.
+	
+	You must follow the process in either the ReadMe file or your own process to capture 
+	the Client ID and Client Secret and save them to a CSV credential profile.
+	
+	ReadMe file: https://carlwebster.sharefile.com/d-sb4e144f9ecc48e7b
+
+	To prevent multiple Citrix Cloud authentication prompts, create a profile named 
+	Default.
+
+	This parameter is blank by default.
+	This parameter has an alias of PN.
+.PARAMETER SiteName
+	Site Name to use for the all output files. 
+
+	The default is "cloudxdsite".
+	This parameter has an alias of SN.
+.PARAMETER Administrators
+	Give detailed information for Administrator Scopes and Roles.
+	This parameter is disabled by default.
+	This parameter has an alias of Admins.
+.PARAMETER Applications
+	Gives detailed information for all applications.
+	This parameter is disabled by default.
+	This parameter has an alias of Apps.
+.PARAMETER DeliveryGroups
+	Gives detailed information on all desktops in all Desktop (Delivery) Groups.
+	
+	Using the DeliveryGroups parameter can cause the report to take a very long 
+	time to complete and can generate an extremely long report.
+	
+	Using both the MachineCatalogs and DeliveryGroups parameters can cause the 
+	report to take an extremely long time to complete and generate an exceptionally 
+	long report.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of DG.
+.PARAMETER DeliveryGroupsUtilization
+	Gives a chart with the delivery group utilization for the last 7 days 
+	depending on the information in the database.
+	
+	This option is only available when the report is generated in Word and requires 
+	Microsoft Excel to be locally installed.
+	
+	Using the DeliveryGroupsUtilization parameter causes the report to take a longer 
+	time to complete and generates a longer report.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of DGU.
+.PARAMETER Hosting
+	Give detailed information for Hosts, Host Connections, and Resources.
+
+	This parameter is disabled by default.
+	This parameter has an alias of Host.
+.PARAMETER Logging
+	Give the Configuration Logging report with, by default, details for the previous 
+	seven days.
+	
+	For Citrix Cloud, there are no Logging preferences or information about the logging 
+	database.
+
+	This parameter is disabled by default.
+.PARAMETER StartDate
+	The start date for the Configuration Logging report.
+	
+	The format for date only is MM/DD/YYYY.
+	
+	Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
+	The double quotes are needed.
+	
+	The default is today's date minus seven days.
+	This parameter has an alias of SD.
+.PARAMETER EndDate
+	The end date for the Configuration Logging report.
+	
+	The format for date only is MM/DD/YYYY.
+	
+	Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
+	The double quotes are needed.
+	
+	The default is today's date.
+	This parameter has an alias of ED.
+.PARAMETER MachineCatalogs
+	Gives detailed information for all machines in all Machine Catalogs.
+	
+	Using the MachineCatalogs parameter can cause the report to take a very long 
+	time to complete and can generate an extremely long report.
+	
+	Using both the MachineCatalogs and DeliveryGroups parameters can cause the 
+	report to take an extremely long time to complete and generate an exceptionally 
+	long report.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of MC.
+.PARAMETER NoADPolicies
+	Excludes all Citrix AD-based policy information from the output document.
+	Includes only Site policies created in Studio.
+	
+	This Switch is useful in large AD environments, where there may be thousands
+	of policies, to keep SYSVOL from being searched.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of NoAD.
+.PARAMETER NoPolicies
+	Excludes all Site and Citrix AD-based policy information from the output document.
+	
+	Using the NoPolicies parameter will cause the Policies parameter to be set to False.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of NP.
+.PARAMETER NoSessions
+	Excludes Machine Catalog, Application and Hosting session data from the report.
+	
+	Using the MaxDetails parameter does not change this setting.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of NS.
+.PARAMETER Policies
+	Give detailed information for both Site and Citrix AD based Policies.
+	
+	Using the Policies parameter can cause the report to take a very long time 
+	to complete and can generate an extremely long report.
+	
+	Note: The Citrix Group Policy PowerShell module will not load from an elevated 
+	PowerShell session. 
+	If the module is manually imported, the module is not detected from an elevated 
+	PowerShell session.
+	
+	There are three related parameters: Policies, NoPolicies, and NoADPolicies.
+	
+	Policies and NoPolicies are mutually exclusive and priority is given to NoPolicies.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of Pol.
+.PARAMETER StoreFront
+	Give detailed information for StoreFront.
+	This parameter is disabled by default.
+	This parameter has an alias of SF.
+.PARAMETER VDARegistryKeys
+	Adds information on registry keys to the Machine Details section.
+	
+	If this parameter is used, MachineCatalogs is set to True.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of VRK.
+.PARAMETER MaxDetails
+	Adds maximum detail to the report.
+	
+	This is the same as using the following parameters:
+		Administrators
+		Applications
+		DeliveryGroups
+		Hosting
+		Logging
+		MachineCatalogs
+		Policies
+		StoreFront
+		VDARegistryKeys
+
+	Does not change the value of NoADPolicies.
+	Does not change the value of NoSessions.
+	
+	WARNING: Using this parameter can create an extremely large report and 
+	can take a very long time to run.
+
+	This parameter has an alias of MAX.
+.PARAMETER Section
+	Processes a specific section of the report.
+	Valid options are:
+		Admins (Administrators)
+		Apps (Applications and Application Group Details)
+		AppV
+		Catalogs (Machine Catalogs)
+		Config (Configuration)
+		Groups (Delivery Groups)
+		Hosting
+		Licensing
+		Logging
+		Policies
+		StoreFront
+		Zones
+		All
+	This parameter defaults to All sections.
+	
+	Notes:
+	Using Logging will force the Logging Switch to True.
+	Using Policies will force the Policies Switch to True.
+	If Policies is selected and the NoPolicies Switch is used, the script will terminate.
+.PARAMETER AddDateTime
+	Adds a date timestamp to the end of the file name.
+	The timestamp is in the format of yyyy-MM-dd_HHmm.
+	June 1, 2020 at 6PM is 2020-06-01_1800.
+	Output filename will be ReportName_2020-06-01_1800.docx (or.pdf).
+	This parameter is disabled by default.
+	This parameter has an alias of ADT.
+.PARAMETER CSV
+	Will create a CSV file for each Appendix.
+	The default value is False.
+	
+	Output CSV filename is in the format:
+	
+	CCSiteName_Documentation_Appendix#_NameOfAppendix.csv
+	
+	For example:
+		CCSiteName_Documentation_AppendixA_VDARegistryItems.csv
+.PARAMETER Dev
+	Clears errors at the beginning of the script.
+	Outputs all errors to a text file at the end of the script.
+	
+	This is used when the script developer requests more troubleshooting data.
+	The text file is placed in the same folder from where the script is run.
+	
+	This parameter is disabled by default.
+.PARAMETER Folder
+	Specifies the optional output folder to save the output report. 
+.PARAMETER Log
+	Generates a log file for troubleshooting.
+.PARAMETER ScriptInfo
+	Outputs information about the script to a text file.
+	The text file is placed in the same folder from where the script is run.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of SI.
 .PARAMETER MSWord
 	SaveAs DOCX file
 	This parameter is disabled by default.
@@ -94,24 +324,6 @@
 	The PDF file is roughly 5X to 10X larger than the DOCX file.
 	This parameter requires Microsoft Word to be installed.
 	This parameter uses the Word SaveAs PDF capability.
-.PARAMETER Text
-	Creates a formatted text file with a.txt extension.
-	This parameter is disabled by default.
-.PARAMETER AddDateTime
-	Adds a date timestamp to the end of the file name.
-	The timestamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2020 at 6PM is 2020-06-01_1800.
-	Output filename will be ReportName_2020-06-01_1800.docx (or.pdf).
-	This parameter is disabled by default.
-	This parameter has an alias of ADT.
-.PARAMETER Administrators
-	Give detailed information for Administrator Scopes and Roles.
-	This parameter is disabled by default.
-	This parameter has an alias of Admins.
-.PARAMETER Applications
-	Gives detailed information for all applications.
-	This parameter is disabled by default.
-	This parameter has an alias of Apps.
 .PARAMETER CompanyAddress
 	Company Address to use for the Cover Page, if the Cover Page has the Address field.
 	
@@ -172,9 +384,9 @@
 		Alphabet (Word 2010. Works)
 		Annual (Word 2010. Doesn't work well for this report)
 		Austere (Word 2010. Works)
-		Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly 
-		works in 2010 but Subtitle/Subject & Author fields need to be moved 
-		after title box is moved up)
+		Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
+		works in 2010, but Subtitle/Subject & Author fields need moving
+		after the title box is moved up)
 		Banded (Word 2013/2016. Works)
 		Conservative (Word 2010. Works)
 		Contrast (Word 2010. Works)
@@ -211,223 +423,11 @@
 	The default value is Sideline.
 	This parameter has an alias of CP.
 	This parameter is only valid with the MSWORD and PDF output parameters.
-.PARAMETER CSV
-	Will create a CSV file for each Appendix.
-	The default value is False.
-	
-	Output CSV filename is in the format:
-	
-	CCSiteName_Documentation_Appendix#_NameOfAppendix.csv
-	
-	For example:
-		CCSiteName_Documentation_AppendixA_VDARegistryItems.csv
-.PARAMETER DeliveryGroups
-	Gives detailed information on all desktops in all Desktop (Delivery) Groups.
-	
-	Using the DeliveryGroups parameter can cause the report to take a very long 
-	time to complete and can generate an extremely long report.
-	
-	Using both the MachineCatalogs and DeliveryGroups parameters can cause the 
-	report to take an extremely long time to complete and generate an exceptionally 
-	long report.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of DG.
-.PARAMETER DeliveryGroupsUtilization
-	Gives a chart with the delivery group utilization for the last 7 days 
-	depending on the information in the database.
-	
-	This option is only available when the report is generated in Word and requires 
-	Microsoft Excel to be locally installed.
-	
-	Using the DeliveryGroupsUtilization parameter causes the report to take a longer 
-	time to complete and generates a longer report.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of DGU.
-.PARAMETER Dev
-	Clears errors at the beginning of the script.
-	Outputs all errors to a text file at the end of the script.
-	
-	This is used when the script developer requests more troubleshooting data.
-	The text file is placed in the same folder from where the script is run.
-	
-	This parameter is disabled by default.
-.PARAMETER EndDate
-	The end date for the Configuration Logging report.
-	
-	The format for date only is MM/DD/YYYY.
-	
-	Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
-	The double quotes are needed.
-	
-	The default is today's date.
-	This parameter has an alias of ED.
-.PARAMETER Folder
-	Specifies the optional output folder to save the output report. 
-.PARAMETER Hosting
-	Give detailed information for Hosts, Host Connections, and Resources.
-
-	This parameter is disabled by default.
-	This parameter has an alias of Host.
-.PARAMETER Log
-	Generates a log file for troubleshooting.
-.PARAMETER Logging
-	Give the Configuration Logging report with, by default, details for the previous 
-	seven days.
-	
-	For Citrix Cloud, there are no Logging preferences or information about the logging 
-	database.
-
-	This parameter is disabled by default.
-.PARAMETER MachineCatalogs
-	Gives detailed information for all machines in all Machine Catalogs.
-	
-	Using the MachineCatalogs parameter can cause the report to take a very long 
-	time to complete and can generate an extremely long report.
-	
-	Using both the MachineCatalogs and DeliveryGroups parameters can cause the 
-	report to take an extremely long time to complete and generate an exceptionally 
-	long report.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of MC.
-.PARAMETER MaxDetails
-	Adds maximum detail to the report.
-	
-	This is the same as using the following parameters:
-		Administrators
-		Applications
-		DeliveryGroups
-		Hosting
-		Logging
-		MachineCatalogs
-		Policies
-		StoreFront
-		VDARegistryKeys
-
-	Does not change the value of NoADPolicies.
-	Does not change the value of NoSessions.
-	
-	WARNING: Using this parameter can create an extremely large report and 
-	can take a very long time to run.
-
-	This parameter has an alias of MAX.
-.PARAMETER NoADPolicies
-	Excludes all Citrix AD-based policy information from the output document.
-	Includes only Site policies created in Studio.
-	
-	This Switch is useful in large AD environments, where there may be thousands
-	of policies, to keep SYSVOL from being searched.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of NoAD.
-.PARAMETER NoPolicies
-	Excludes all Site and Citrix AD-based policy information from the output document.
-	
-	Using the NoPolicies parameter will cause the Policies parameter to be set to False.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of NP.
-.PARAMETER NoSessions
-	Excludes Machine Catalog, Application and Hosting session data from the report.
-	
-	Using the MaxDetails parameter does not change this setting.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of NS.
-.PARAMETER Policies
-	Give detailed information for both Site and Citrix AD based Policies.
-	
-	Using the Policies parameter can cause the report to take a very long time 
-	to complete and can generate an extremely long report.
-	
-	Note: The Citrix Group Policy PowerShell module will not load from an elevated 
-	PowerShell session. 
-	If the module is manually imported, the module is not detected from an elevated 
-	PowerShell session.
-	
-	There are three related parameters: Policies, NoPolicies, and NoADPolicies.
-	
-	Policies and NoPolicies are mutually exclusive and priority is given to NoPolicies.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of Pol.
-.PARAMETER ProfileName
-	The profile name to use for Get-XDAuthentication.
-	
-	The name associated with a set of credentials in the local store that are to be 
-	read.
-	
-	You must follow the process in either the ReadMe file or your own process to capture 
-	the Client ID and Client Secret and save them to a CSV credential profile.
-	
-	ReadMe file: https://carlwebster.sharefile.com/d-sb4e144f9ecc48e7b
-
-	To prevent multiple Citrix Cloud authentication prompts, create a profile named 
-	Default.
-
-	This parameter is blank by default.
-	This parameter has an alias of PN.
-.PARAMETER ScriptInfo
-	Outputs information about the script to a text file.
-	The text file is placed in the same folder from where the script is run.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of SI.
-.PARAMETER Section
-	Processes a specific section of the report.
-	Valid options are:
-		Admins (Administrators)
-		Apps (Applications and Application Group Details)
-		AppV
-		Catalogs (Machine Catalogs)
-		Config (Configuration)
-		Groups (Delivery Groups)
-		Hosting
-		Licensing
-		Logging
-		Policies
-		StoreFront
-		Zones
-		All
-	This parameter defaults to All sections.
-	
-	Notes:
-	Using Logging will force the Logging Switch to True.
-	Using Policies will force the Policies Switch to True.
-	If Policies is selected and the NoPolicies Switch is used, the script will terminate.
-.PARAMETER SiteName
-	Site Name to use for the all output files. 
-
-	The default is "cloudxdsite".
-	This parameter has an alias of SN.
-.PARAMETER StartDate
-	The start date for the Configuration Logging report.
-	
-	The format for date only is MM/DD/YYYY.
-	
-	Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24-hour format.
-	The double quotes are needed.
-	
-	The default is today's date minus seven days.
-	This parameter has an alias of SD.
-.PARAMETER StoreFront
-	Give detailed information for StoreFront.
-	This parameter is disabled by default.
-	This parameter has an alias of SF.
 .PARAMETER UserName
 	Username to use for the Cover Page and Footer.
 	The default value is contained in $env:username
 	This parameter has an alias of UN.
 	This parameter is only valid with the MSWORD and PDF output parameters.
-.PARAMETER VDARegistryKeys
-	Adds information on registry keys to the Machine Details section.
-	
-	If this parameter is used, MachineCatalogs is set to True.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of VRK.
 .PARAMETER SmtpServer
 	Specifies the optional email server to send the output report. 
 .PARAMETER SmtpPort
@@ -1126,19 +1126,17 @@ Param(
 	[parameter(Mandatory=$False)] 
 	[Switch]$HTML=$False,
 
-	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
-	[Switch]$MSWord=$False,
-
-	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
-	[Switch]$PDF=$False,
-
 	[parameter(Mandatory=$False)] 
 	[Switch]$Text=$False,
 
 	[parameter(Mandatory=$False)] 
-	[Alias("ADT")]
-	[Switch]$AddDateTime=$False,
+	[Alias("PN")]
+	[string]$ProfileName="",	
 	
+	[parameter(Mandatory=$False)] 
+	[Alias("SN")]
+	[string]$SiteName="",
+    
 	[parameter(Mandatory=$False)] 
 	[Alias("Admins")]
 	[Switch]$Administrators=$False,	
@@ -1147,6 +1145,92 @@ Param(
 	[Alias("Apps")]
 	[Switch]$Applications=$False,	
 	
+	[parameter(Mandatory=$False)] 
+	[Alias("DG")]
+	[Switch]$DeliveryGroups=$False,	
+
+	[parameter(Mandatory=$False)] 
+	[Alias("DGU")]
+	[Switch]$DeliveryGroupsUtilization=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("Host")]
+	[Switch]$Hosting=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Switch]$Logging=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("SD")]
+	[Datetime]$StartDate = ((Get-Date -displayhint date).AddDays(-7)),
+
+	[parameter(Mandatory=$False)] 
+	[Alias("ED")]
+	[Datetime]$EndDate = (Get-Date -displayhint date),
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("MC")]
+	[Switch]$MachineCatalogs=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("NoAD")]
+	[Switch]$NoADPolicies=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("NP")]
+	[Switch]$NoPolicies=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("NS")]
+	[Switch]$NoSessions=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("Pol")]
+	[Switch]$Policies=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("SF")]
+	[Switch]$StoreFront=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("VRK")]
+	[Switch]$VDARegistryKeys=$False,
+
+	[parameter(Mandatory=$False)] 
+	[Alias("MAX")]
+	[Switch]$MaxDetails=$False,
+
+	[ValidateSet('All', 'Admins', 'Apps', 'AppV', 'Catalogs', 'Config', 'Groups', 
+	'Hosting', 'Licensing', 'Logging', 'Policies', 'StoreFront', 'Zones')]
+	[parameter(Mandatory=$False)] 
+	[string]$Section="All",
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("ADT")]
+	[Switch]$AddDateTime=$False,
+	
+	[parameter(Mandatory=$False)] 
+	[Switch]$CSV=$False,
+
+	[parameter(Mandatory=$False)] 
+	[Switch]$Dev=$False,
+	
+	[parameter(Mandatory=$False)] 
+	[string]$Folder="",
+	
+	[parameter(Mandatory=$False)] 
+	[Switch]$Log=$False,
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("SI")]
+	[Switch]$ScriptInfo=$False,
+	
+	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
+	[Switch]$MSWord=$False,
+
+	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
+	[Switch]$PDF=$False,
+
 	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
 	[Alias("CA")]
 	[ValidateNotNullOrEmpty()]
@@ -1177,94 +1261,10 @@ Param(
 	[ValidateNotNullOrEmpty()]
 	[string]$CoverPage="Sideline", 
 
-	[parameter(Mandatory=$False)] 
-	[Switch]$CSV=$False,
-
-	[parameter(Mandatory=$False)] 
-	[Alias("DG")]
-	[Switch]$DeliveryGroups=$False,	
-
-	[parameter(Mandatory=$False)] 
-	[Alias("DGU")]
-	[Switch]$DeliveryGroupsUtilization=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Switch]$Dev=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("ED")]
-	[Datetime]$EndDate = (Get-Date -displayhint date),
-	
-	[parameter(Mandatory=$False)] 
-	[string]$Folder="",
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("Host")]
-	[Switch]$Hosting=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Switch]$Log=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[Switch]$Logging=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("MC")]
-	[Switch]$MachineCatalogs=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("MAX")]
-	[Switch]$MaxDetails=$False,
-
-	[parameter(Mandatory=$False)] 
-	[Alias("NoAD")]
-	[Switch]$NoADPolicies=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("NP")]
-	[Switch]$NoPolicies=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("NS")]
-	[Switch]$NoSessions=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("PN")]
-	[string]$ProfileName="",	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("Pol")]
-	[Switch]$Policies=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("SI")]
-	[Switch]$ScriptInfo=$False,
-	
-	[ValidateSet('All', 'Admins', 'Apps', 'AppV', 'Catalogs', 'Config', 'Groups', 
-	'Hosting', 'Licensing', 'Logging', 'Policies', 'StoreFront', 'Zones')]
-	[parameter(Mandatory=$False)] 
-	[string]$Section="All",
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("SN")]
-	[string]$SiteName="",
-    
-	[parameter(Mandatory=$False)] 
-	[Alias("SD")]
-	[Datetime]$StartDate = ((Get-Date -displayhint date).AddDays(-7)),
-
-	[parameter(Mandatory=$False)] 
-	[Alias("SF")]
-	[Switch]$StoreFront=$False,	
-	
 	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
 	[Alias("UN")]
 	[ValidateNotNullOrEmpty()]
 	[string]$UserName=$env:username,
-
-	[parameter(Mandatory=$False)] 
-	[Alias("VRK")]
-	[Switch]$VDARegistryKeys=$False,
 
 	[parameter(Mandatory=$False)] 
 	[string]$SmtpServer="",
@@ -1293,7 +1293,7 @@ Param(
 
 # This script is based on the CVAD V3.00 doc script
 
-#Version 1.10
+#Version 1.10 4-Dec-2020
 #	Added the missing ReadMe file link to the warning message about the missing Citrix.GroupPolicy.Commands file
 #	Added to Hosting Connection section:
 #	(Thanks to fellow CTPs Neil Spellings, Kees Baggerman, and Trond Eirik Haavarstein for getting this info for me)
@@ -1306,6 +1306,7 @@ Param(
 #	Fixed alignment in the Text output for the ScriptInfo output file
 #	Fixed bug reported by David Prows in the Hosting section. First, check to see if the hosting connection's 
 #		AdditionalStorage.StorageLocations is valid
+#	For all calls to Get-AdminAdministrator, remove the -SortBy Name. Sorting by Name is the default behavior.
 #	For MCS Machine Catalogs:
 #		Check that the catalog's ProvisioningSchemeId is not $Null before retrieving the Provision Scheme's machine data
 #		Check that $MachineData is not $Null before checking for HostingUnitName
@@ -1321,6 +1322,7 @@ Param(
 #	In Function OutputPerZoneView, add "There are no zone members for Zone <ZoneName>" to replace blank tables and text output
 #	Provide full details in the error message if the Citrix.Common.GroupPolicy snapin is missing (Thanks to Guy Leech for the suggestion)
 #	Removed Controllers from the ScriptInfo output file and the Section parameter switch statement
+#	Reordered the parameters in an order recommended by Guy Leech
 #	Updated the ReadMe file
 #
 #Version 1.00 21-Sep-2020
@@ -4845,7 +4847,7 @@ Function GetAdmins
 			Select-Object -ExpandProperty Id
 
 			#this is an unscoped object type as $admins is done differently than the others
-			$Admins = Get-AdminAdministrator @CCParams2 -SortBy Name | `
+			$Admins = Get-AdminAdministrator @CCParams2 | `
 			Where-Object {$_.UserIdentityType -ne "Sid" -and (-not ([String]::IsNullOrEmpty($_.UserIdentityType)))} | `
 			Where-Object {$_.Rights | Where-Object {$roles -contains $_.RoleId}}
 		}
@@ -4860,7 +4862,7 @@ Function GetAdmins
 			Where-Object {$_.Permissions | Where-Object { $permissions -contains $_ }} | `
 			Select-Object -ExpandProperty Id
 
-			$Admins = Get-AdminAdministrator @CCParams2 -SortBy Name | `
+			$Admins = Get-AdminAdministrator @CCParams2 | `
 			Where-Object {$_.UserIdentityType -ne "Sid" -and (-not ([String]::IsNullOrEmpty($_.Name)))} | `
 			Where-Object {$_.Rights | `
 			Where-Object {($_.ScopeId -eq [guid]::Empty -or $scopes -contains $_.ScopeId) -and $roles -contains $_.RoleId}}
@@ -4877,7 +4879,7 @@ Function GetAdmins
 			Where-Object {$_.Permissions | Where-Object { $permissions -contains $_ }} | `
 			Select-Object -ExpandProperty Id
 
-			$Admins = Get-AdminAdministrator @CCParams2 -SortBy Name | `
+			$Admins = Get-AdminAdministrator @CCParams2 | `
 			Where-Object {$_.UserIdentityType -ne "Sid" -and (-not ([String]::IsNullOrEmpty($_.Name)))} | `
 			Where-Object {$_.Rights | `
 			Where-Object {($_.ScopeId -eq [guid]::Empty -or $scopes -contains $_.ScopeId) -and $roles -contains $_.RoleId}}
@@ -4897,7 +4899,7 @@ Function GetAdmins
 			    Where-Object {$_.Permissions | Where-Object { $permissions -contains $_ }} | `
 			    Select-Object -ExpandProperty Id
 
-			    $Admins = Get-AdminAdministrator @CCParams2 -SortBy Name | `
+			    $Admins = Get-AdminAdministrator @CCParams2 | `
 			    Where-Object {$_.UserIdentityType -ne "Sid" -and (-not ([String]::IsNullOrEmpty($_.Name)))} | `
 			    Where-Object {$_.Rights | `
 			    Where-Object {($_.ScopeId -eq [guid]::Empty -or `
@@ -4917,7 +4919,7 @@ Function GetAdmins
 			    Where-Object {$_.Permissions | Where-Object { $permissions -contains $_ }} | `
 			    Select-Object -ExpandProperty Id
 
-			    $Admins = Get-AdminAdministrator @CCParams2 -SortBy Name | `
+			    $Admins = Get-AdminAdministrator @CCParams2 | `
 			    Where-Object {$_.UserIdentityType -ne "Sid" -and (-not ([String]::IsNullOrEmpty($_.Name)))} | `
 			    Where-Object {$_.Rights | `
 			    Where-Object {($_.ScopeId -eq [guid]::Empty -or `
@@ -4936,7 +4938,7 @@ Function GetAdmins
 			Select-Object -ExpandProperty Id
 
 			#this is an unscoped object type as $admins is done differently than the others
-			$Admins = Get-AdminAdministrator @CCParams2 -SortBy Name | `
+			$Admins = Get-AdminAdministrator @CCParams2 | `
 			Where-Object {$_.UserIdentityType -ne "Sid" -and (-not ([String]::IsNullOrEmpty($_.Name)))} | `
 			Where-Object {$_.Rights | `
 			Where-Object {$roles -contains $_.RoleId}}
@@ -26173,7 +26175,7 @@ Function ProcessAdministrators
 	Write-Verbose "$(Get-Date -Format G): Processing Administrators"
 	Write-Verbose "$(Get-Date -Format G): `tRetrieving Administrator data"
 	
-	$Admins = Get-AdminAdministrator @CCParams2 -SortBy Name | `
+	$Admins = Get-AdminAdministrator @CCParams2 | `
 	Where-Object {$_.UserIdentityType -ne "Sid" -and (-not [String]::IsNullOrEmpty($_.Name))}
 
 	If($? -and ($Null -ne $Admins))

--- a/CC_Inventory_V1.ps1
+++ b/CC_Inventory_V1.ps1
@@ -1305,6 +1305,7 @@ Param(
 #		Remote PC Wake on LAN
 #	Added variables, counters, and text for the following Administrative Roles
 #		Cloud Administrator: [int]$Script:TotalCloudAdmins
+#		Full Monitor Administrator: [int]$Script:TotalFullMonitorAdmins
 #		Probe Agent Administrator: [int]$Script:TotalProbeAdmins
 #		Session Administrator: [int]$Script:TotalSessionAdmins
 #	Correct the invalid variable name in the ScriptInfo output file for WordFilename
@@ -1748,6 +1749,7 @@ If($Dev)
 [int]$Script:TotalCloudAdmins            = 0
 [int]$Script:TotalDeliveryGroupAdmins    = 0
 [int]$Script:TotalFullAdmins             = 0
+[int]$Script:TotalFullMonitorAdmins      = 0
 [int]$Script:TotalHelpDeskAdmins         = 0
 [int]$Script:TotalHostAdmins             = 0
 [int]$Script:TotalMachineCatalogAdmins   = 0
@@ -26230,6 +26232,7 @@ Function OutputAdministrators
 			"Cloud Administrator"			{$Script:TotalCloudAdmins++}
 			"Delivery Group Administrator"	{$Script:TotalDeliveryGroupAdmins++}
 			"Full Administrator"			{$Script:TotalFullAdmins++}
+			"Full Monitor Administrator"	{$Script:TotalFullMonitorAdmins++}
 			"Help Desk Administrator"		{$Script:TotalHelpDeskAdmins++}
 			"Host Administrator"			{$Script:TotalHostAdmins++}
 			"Machine Catalog Administrator"	{$Script:TotalMachineCatalogAdmins++}
@@ -29830,6 +29833,7 @@ Function OutputSummaryPage
 		$ScriptInformation.Add(@{Data = "Total Cloud Admins"; Value = $Script:TotalCloudAdmins.ToString(); }) > $Null
 		$ScriptInformation.Add(@{Data = "Total Delivery Group Admins"; Value = $Script:TotalDeliveryGroupAdmins.ToString(); }) > $Null
 		$ScriptInformation.Add(@{Data = 'Total Full Admins'; Value = $Script:TotalFullAdmins.ToString(); }) > $Null
+		$ScriptInformation.Add(@{Data = 'Total Full Monitor Admins'; Value = $Script:TotalFullMonitorAdmins.ToString(); }) > $Null
 		$ScriptInformation.Add(@{Data = 'Total Help Desk Admins'; Value = $Script:TotalHelpDeskAdmins.ToString(); }) > $Null
 		$ScriptInformation.Add(@{Data = 'Total Host Admins'; Value = $Script:TotalHostAdmins.ToString(); }) > $Null
 		$ScriptInformation.Add(@{Data = 'Total Machine Catalog Admins'; Value = $Script:TotalMachineCatalogAdmins.ToString(); }) > $Null
@@ -29841,6 +29845,7 @@ Function OutputSummaryPage
 		$Script:TotalCloudAdmins+
 		$Script:TotalDeliveryGroupAdmins+
 		$Script:TotalFullAdmins+
+		$Script:TotalFullMonitorAdmins+
 		$Script:TotalHelpDeskAdmins+
 		$Script:TotalHostAdmins+
 		$Script:TotalMachineCatalogAdmins+
@@ -29971,6 +29976,7 @@ Function OutputSummaryPage
 		Line 1 "Total Cloud Admins`t`t: " $Script:TotalCloudAdmins
 		Line 1 "Total Delivery Group Admins`t: " $Script:TotalDeliveryGroupAdmins
 		Line 1 "Total Full Admins`t`t: " $Script:TotalFullAdmins
+		Line 1 "Total Full Monitor Admins`t: " $Script:TotalFullMonitorAdmins
 		Line 1 "Total Help Desk Admins`t`t: " $Script:TotalHelpDeskAdmins
 		Line 1 "Total Host Admins`t`t: " $Script:TotalHostAdmins
 		Line 1 "Total Machine Catalog Admins`t: " $Script:TotalMachineCatalogAdmins
@@ -29982,6 +29988,7 @@ Function OutputSummaryPage
 		$Script:TotalCloudAdmins+
 		$Script:TotalDeliveryGroupAdmins+
 		$Script:TotalFullAdmins+
+		$Script:TotalFullMonitorAdmins+
 		$Script:TotalHelpDeskAdmins+
 		$Script:TotalHostAdmins+
 		$Script:TotalMachineCatalogAdmins+
@@ -30056,6 +30063,7 @@ Function OutputSummaryPage
 		$columnHeaders = @("Total Cloud Admins",($global:htmlsb),$Script:TotalCloudAdmins.ToString(),$htmlwhite)
 		$rowdata += @(,('Total Delivery Group Admins',($global:htmlsb),$Script:TotalDeliveryGroupAdmins.ToString(),$htmlwhite))
 		$rowdata += @(,('Total Full Admins',($global:htmlsb),$Script:TotalFullAdmins.ToString(),$htmlwhite))
+		$rowdata += @(,('Total Full Monitor Admins',($global:htmlsb),$Script:TotalFullMonitorAdmins.ToString(),$htmlwhite))
 		$rowdata += @(,('Total Help Desk Admins',($global:htmlsb),$Script:TotalHelpDeskAdmins.ToString(),$htmlwhite))
 		$rowdata += @(,('Total Host Admins',($global:htmlsb),$Script:TotalHostAdmins.ToString(),$htmlwhite))
 		$rowdata += @(,('Total Machine Catalog Admins',($global:htmlsb),$Script:TotalMachineCatalogAdmins.ToString(),$htmlwhite))
@@ -30067,6 +30075,7 @@ Function OutputSummaryPage
 		$Script:TotalCloudAdmins+
 		$Script:TotalDeliveryGroupAdmins+
 		$Script:TotalFullAdmins+
+		$Script:TotalFullMonitorAdmins+
 		$Script:TotalHelpDeskAdmins+
 		$Script:TotalHostAdmins+
 		$Script:TotalMachineCatalogAdmins+

--- a/CC_Inventory_V1.ps1
+++ b/CC_Inventory_V1.ps1
@@ -1113,7 +1113,7 @@
 	NAME: CC_Inventory_V1.ps1
 	VERSION: 1.10
 	AUTHOR: Carl Webster
-	LASTEDIT: December 3, 2020
+	LASTEDIT: December 5, 2020
 #>
 
 #endregion
@@ -1293,7 +1293,7 @@ Param(
 
 # This script is based on the CVAD V3.00 doc script
 
-#Version 1.10
+#Version 1.10 5-Dec-2020
 #	Added CustomerID to function ShowScriptInfo and ProcessScriptEnd
 #	Added the missing ReadMe file link to the warning message about the missing Citrix.GroupPolicy.Commands file
 #	Added to Hosting Connection section:
@@ -1326,7 +1326,32 @@ Param(
 #		<MachineName> was not found in DNS. VDA Registry Key data cannot be gathered.
 #		Otherwise, every machine was reported as offline, which may not be true.
 #	In Function OutputPerZoneView, add "There are no zone members for Zone <ZoneName>" to replace blank tables and text output
-#	In Function OutputSummaryPage, add text for Cloud, Probe Agent, and Session Administrators
+#	In Function OutputSummaryPage, add text for Cloud, Full Monitor, Probe Agent, and Session Administrators
+#	KNOWN ISSUE: 
+#		A few users report they get the following errors even in a new elevated PowerShell session:
+#			"Import-Module : A drive with the name 'XDHyp' already exists."
+#			"ProcessScriptSetup : Unable to import the Citrix.Host.Commands module. Script cannot continue."
+#		Even if the script runs for these users, the Hosting section contains no usable data.
+#			Hosting
+#				Unable to retrieve Hosting Units
+#			
+#				Unable to retrieve Hosting Connections
+#			 
+#			My-Hosting-ConnectioName
+#				Connection Name		My-Hosting-ConnectioName
+#				Type				Hypervisor Type could not be determined:
+#				Address	   
+#				State				Disabled
+#				Username	   
+#				Scopes	   
+#				Maintenance Mode	Off
+#				Zone	   
+#				Storage resource name	   
+#
+#			Advanced
+#				Connection Name		My-Hosting-ConnectioName
+#				Unable to retrieve Hosting Connections
+#		I have been unable to determine the root cause, a resolution, or a workaround for this issue
 #	Provide full details in the error message if the Citrix.Common.GroupPolicy snapin is missing (Thanks to Guy Leech for the suggestion)
 #	Removed all references to $Script:CCParams1 and @CCParams1
 #	Removed all references to AdminAddress

--- a/CC_V1_Script_ChangeLog.txt
+++ b/CC_V1_Script_ChangeLog.txt
@@ -6,7 +6,7 @@
 
 # This script is based on the CVAD V3.00 doc script
 
-#Version 1.10
+#Version 1.10 4-Dec-2020
 #	Added the missing ReadMe file link to the warning message about the missing Citrix.GroupPolicy.Commands file
 #	Added to Hosting Connection section:
 #	(Thanks to fellow CTPs Neil Spellings, Kees Baggerman, and Trond Eirik Haavarstein for getting this info for me)
@@ -19,6 +19,7 @@
 #	Fixed alignment in the Text output for the ScriptInfo output file
 #	Fixed bug reported by David Prows in the Hosting section. First, check to see if the hosting connection's 
 #		AdditionalStorage.StorageLocations is valid
+#	For all calls to Get-AdminAdministrator, remove the -SortBy Name. Sorting by Name is the default behavior.
 #	For MCS Machine Catalogs:
 #		Check that the catalog's ProvisioningSchemeId is not $Null before retrieving the Provision Scheme's machine data
 #		Check that $MachineData is not $Null before checking for HostingUnitName
@@ -34,6 +35,7 @@
 #	In Function OutputPerZoneView, add "There are no zone members for Zone <ZoneName>" to replace blank tables and text output
 #	Provide full details in the error message if the Citrix.Common.GroupPolicy snapin is missing (Thanks to Guy Leech for the suggestion)
 #	Removed Controllers from the ScriptInfo output file and the Section parameter switch statement
+#	Reordered the parameters in an order recommended by Guy Leech
 #	Updated the ReadMe file
 
 #Version 1.00 21-Sep-2020

--- a/CC_V1_Script_ChangeLog.txt
+++ b/CC_V1_Script_ChangeLog.txt
@@ -18,6 +18,7 @@
 #		Remote PC Wake on LAN
 #	Added variables, counters, and text for the following Administrative Roles
 #		Cloud Administrator: [int]$Script:TotalCloudAdmins
+#		Full Monitor Administrator: [int]$Script:TotalFullMonitorAdmins
 #		Probe Agent Administrator: [int]$Script:TotalProbeAdmins
 #		Session Administrator: [int]$Script:TotalSessionAdmins
 #	Correct the invalid variable name in the ScriptInfo output file for WordFilename

--- a/CC_V1_Script_ChangeLog.txt
+++ b/CC_V1_Script_ChangeLog.txt
@@ -6,7 +6,7 @@
 
 # This script is based on the CVAD V3.00 doc script
 
-#Version 1.10
+#Version 1.10 5-Dec-2020
 #	Added CustomerID to function ShowScriptInfo and ProcessScriptEnd
 #	Added the missing ReadMe file link to the warning message about the missing Citrix.GroupPolicy.Commands file
 #	Added to Hosting Connection section:
@@ -39,7 +39,32 @@
 #		<MachineName> was not found in DNS. VDA Registry Key data cannot be gathered.
 #		Otherwise, every machine was reported as offline, which may not be true.
 #	In Function OutputPerZoneView, add "There are no zone members for Zone <ZoneName>" to replace blank tables and text output
-#	In Function OutputSummaryPage, add text for Cloud, Probe Agent, and Session Administrators
+#	In Function OutputSummaryPage, add text for Cloud, Full Monitor, Probe Agent, and Session Administrators
+#	KNOWN ISSUE: 
+#		A few users report they get the following errors even in a new elevated PowerShell session:
+#			"Import-Module : A drive with the name 'XDHyp' already exists."
+#			"ProcessScriptSetup : Unable to import the Citrix.Host.Commands module. Script cannot continue."
+#		Even if the script runs for these users, the Hosting section contains no usable data.
+#			Hosting
+#				Unable to retrieve Hosting Units
+#			
+#				Unable to retrieve Hosting Connections
+#			 
+#			My-Hosting-ConnectioName
+#				Connection Name		My-Hosting-ConnectioName
+#				Type				Hypervisor Type could not be determined:
+#				Address	   
+#				State				Disabled
+#				Username	   
+#				Scopes	   
+#				Maintenance Mode	Off
+#				Zone	   
+#				Storage resource name	   
+#
+#			Advanced
+#				Connection Name		My-Hosting-ConnectioName
+#				Unable to retrieve Hosting Connections
+#		I have been unable to determine the root cause, a resolution, or a workaround for this issue
 #	Provide full details in the error message if the Citrix.Common.GroupPolicy snapin is missing (Thanks to Guy Leech for the suggestion)
 #	Removed all references to $Script:CCParams1 and @CCParams1
 #	Removed all references to AdminAddress

--- a/CC_V1_Script_ChangeLog.txt
+++ b/CC_V1_Script_ChangeLog.txt
@@ -6,7 +6,8 @@
 
 # This script is based on the CVAD V3.00 doc script
 
-#Version 1.10 4-Dec-2020
+#Version 1.10
+#	Added CustomerID to function ShowScriptInfo and ProcessScriptEnd
 #	Added the missing ReadMe file link to the warning message about the missing Citrix.GroupPolicy.Commands file
 #	Added to Hosting Connection section:
 #	(Thanks to fellow CTPs Neil Spellings, Kees Baggerman, and Trond Eirik Haavarstein for getting this info for me)
@@ -15,6 +16,10 @@
 #		Microsoft Azure
 #		Nutanix AHV
 #		Remote PC Wake on LAN
+#	Added variables, counters, and text for the following Administrative Roles
+#		Cloud Administrator: [int]$Script:TotalCloudAdmins
+#		Probe Agent Administrator: [int]$Script:TotalProbeAdmins
+#		Session Administrator: [int]$Script:TotalSessionAdmins
 #	Correct the invalid variable name in the ScriptInfo output file for WordFilename
 #	Fixed alignment in the Text output for the ScriptInfo output file
 #	Fixed bug reported by David Prows in the Hosting section. First, check to see if the hosting connection's 
@@ -33,8 +38,12 @@
 #		<MachineName> was not found in DNS. VDA Registry Key data cannot be gathered.
 #		Otherwise, every machine was reported as offline, which may not be true.
 #	In Function OutputPerZoneView, add "There are no zone members for Zone <ZoneName>" to replace blank tables and text output
+#	In Function OutputSummaryPage, add text for Cloud, Probe Agent, and Session Administrators
 #	Provide full details in the error message if the Citrix.Common.GroupPolicy snapin is missing (Thanks to Guy Leech for the suggestion)
+#	Removed all references to $Script:CCParams1 and @CCParams1
+#	Removed all references to AdminAddress
 #	Removed Controllers from the ScriptInfo output file and the Section parameter switch statement
+#	Removed Licensing from the Summary Page because there are no individual license files in Citrix Cloud
 #	Reordered the parameters in an order recommended by Guy Leech
 #	Updated the ReadMe file
 

--- a/CC_V1_Script_ChangeLog.txt
+++ b/CC_V1_Script_ChangeLog.txt
@@ -6,6 +6,36 @@
 
 # This script is based on the CVAD V3.00 doc script
 
+#Version 1.10
+#	Added the missing ReadMe file link to the warning message about the missing Citrix.GroupPolicy.Commands file
+#	Added to Hosting Connection section:
+#	(Thanks to fellow CTPs Neil Spellings, Kees Baggerman, and Trond Eirik Haavarstein for getting this info for me)
+#		Amazon EC2    
+#		Google Cloud Platform
+#		Microsoft Azure
+#		Nutanix AHV
+#		Remote PC Wake on LAN
+#	Correct the invalid variable name in the ScriptInfo output file for WordFilename
+#	Fixed alignment in the Text output for the ScriptInfo output file
+#	Fixed bug reported by David Prows in the Hosting section. First, check to see if the hosting connection's 
+#		AdditionalStorage.StorageLocations is valid
+#	For MCS Machine Catalogs:
+#		Check that the catalog's ProvisioningSchemeId is not $Null before retrieving the Provision Scheme's machine data
+#		Check that $MachineData is not $Null before checking for HostingUnitName
+#	For the Hosting section, for High Availability Servers and Power Actions, handle empty arrays
+#	In Function GetAdmins, for Hosting Connections, handle the error "The property 'ScopeId' cannot be found on this object. Verify that the property exists."
+#		Also, added some white space to make the function easier for me to read
+#	In Function OutputAdminsForDetails, add "No Admins found" to replace blank tables and text output
+#	In Function OutputDeliveryGroupCatalogs, handle the case where a Delivery Group has no Machine Catalog(s) assigned
+#	In Function OutputMachineDetails, when using Test-NetConnection, add Resolve-DnsName first to see if the machine name is resolvable. 
+#		This prevents every call to Test-NetConnection from failing with "<MachineName> was not found in DNS". Add error message:
+#		<MachineName> was not found in DNS. VDA Registry Key data cannot be gathered.
+#		Otherwise, every machine was reported as offline, which may not be true.
+#	In Function OutputPerZoneView, add "There are no zone members for Zone <ZoneName>" to replace blank tables and text output
+#	Provide full details in the error message if the Citrix.Common.GroupPolicy snapin is missing (Thanks to Guy Leech for the suggestion)
+#	Removed Controllers from the ScriptInfo output file and the Section parameter switch statement
+#	Updated the ReadMe file
+
 #Version 1.00 21-Sep-2020
 #
 #	Add a switch statement for the machine/desktop/server Power State


### PR DESCRIPTION
#Version 1.10 5-Dec-2020
#	Added CustomerID to function ShowScriptInfo and ProcessScriptEnd
#	Added the missing ReadMe file link to the warning message about the missing Citrix.GroupPolicy.Commands file
#	Added to Hosting Connection section:
#	(Thanks to fellow CTPs Neil Spellings, Kees Baggerman, and Trond Eirik Haavarstein for getting this info for me)
#		Amazon EC2    
#		Google Cloud Platform
#		Microsoft Azure
#		Nutanix AHV
#		Remote PC Wake on LAN
#	Added variables, counters, and text for the following Administrative Roles
#		Cloud Administrator: [int]$Script:TotalCloudAdmins
#		Full Monitor Administrator: [int]$Script:TotalFullMonitorAdmins
#		Probe Agent Administrator: [int]$Script:TotalProbeAdmins
#		Session Administrator: [int]$Script:TotalSessionAdmins
#	Correct the invalid variable name in the ScriptInfo output file for WordFilename
#	Fixed alignment in the Text output for the ScriptInfo output file
#	Fixed bug reported by David Prows in the Hosting section. First, check to see if the hosting connection's 
#		AdditionalStorage.StorageLocations is valid
#	For all calls to Get-AdminAdministrator, remove the -SortBy Name. Sorting by Name is the default behavior.
#	For MCS Machine Catalogs:
#		Check that the catalog's ProvisioningSchemeId is not $Null before retrieving the Provision Scheme's machine data
#		Check that $MachineData is not $Null before checking for HostingUnitName
#	For the Hosting section, for High Availability Servers and Power Actions, handle empty arrays
#	In Function GetAdmins, for Hosting Connections, handle the error "The property 'ScopeId' cannot be found on this object. Verify that the property exists."
#		Also, added some white space to make the function easier for me to read
#	In Function OutputAdminsForDetails, add "No Admins found" to replace blank tables and text output
#	In Function OutputDeliveryGroupCatalogs, handle the case where a Delivery Group has no Machine Catalog(s) assigned
#	In Function OutputMachineDetails, when using Test-NetConnection, add Resolve-DnsName first to see if the machine name is resolvable. 
#		This prevents every call to Test-NetConnection from failing with "<MachineName> was not found in DNS". Add error message:
#		<MachineName> was not found in DNS. VDA Registry Key data cannot be gathered.
#		Otherwise, every machine was reported as offline, which may not be true.
#	In Function OutputPerZoneView, add "There are no zone members for Zone <ZoneName>" to replace blank tables and text output
#	In Function OutputSummaryPage, add text for Cloud, Full Monitor, Probe Agent, and Session Administrators
#	KNOWN ISSUE: 
#		A few users report they get the following errors even in a new elevated PowerShell session:
#			"Import-Module : A drive with the name 'XDHyp' already exists."
#			"ProcessScriptSetup : Unable to import the Citrix.Host.Commands module. Script cannot continue."
#		Even if the script runs for these users, the Hosting section contains no usable data.
#			Hosting
#				Unable to retrieve Hosting Units
#			
#				Unable to retrieve Hosting Connections
#			 
#			My-Hosting-ConnectioName
#				Connection Name		My-Hosting-ConnectioName
#				Type				Hypervisor Type could not be determined:
#				Address	   
#				State				Disabled
#				Username	   
#				Scopes	   
#				Maintenance Mode	Off
#				Zone	   
#				Storage resource name	   
#
#			Advanced
#				Connection Name		My-Hosting-ConnectioName
#				Unable to retrieve Hosting Connections
#		I have been unable to determine the root cause, a resolution, or a workaround for this issue
#	Provide full details in the error message if the Citrix.Common.GroupPolicy snapin is missing (Thanks to Guy Leech for the suggestion)
#	Removed all references to $Script:CCParams1 and @CCParams1
#	Removed all references to AdminAddress
#	Removed Controllers from the ScriptInfo output file and the Section parameter switch statement
#	Removed Licensing from the Summary Page because there are no individual license files in Citrix Cloud
#	Reordered the parameters in an order recommended by Guy Leech
#	Updated the ReadMe file