### PR TITLE
Final update for 1.20

### DIFF
--- a/CC_V1_Script_ChangeLog.txt
+++ b/CC_V1_Script_ChangeLog.txt
@@ -6,6 +6,10 @@
 
 # This script is based on the CVAD V3.00 doc script
 
+#Version 1.20 25-Jul-2022
+#	Added support for Minimum Catalog Level 2206 (L7_34)
+#	Added the missing enums for VDAUpgrade.Type and VDAUpgrade.State to the Machine output
+
 #Version 1.19 16-Jul-2022
 #	Added the missing enums for VDAUpgrade.Type and VDAUpgrade.State
 #		Type:


### PR DESCRIPTION
#Version 1.20 25-Jul-2022
#	Added support for Minimum Catalog Level 2206 (L7_34)
#	Added the missing enums for VDAUpgrade.Type and VDAUpgrade.State to the Machine output