### PR TITLE
Final update for 1.24

### DIFF
--- a/CC_V1_Script_ChangeLog.txt
+++ b/CC_V1_Script_ChangeLog.txt
@@ -6,6 +6,127 @@
 
 # This script is based on the CVAD V3.00 doc script
 
+#Version 1.24 24-Mar-2023
+#	Added settings configurable by Set-BrokerServiceConfigurationData
+#		Core.GetEntitlementTypePeriodHours
+#			Type: int
+#			Default: 24
+#			Info: Hours Minimum=1
+#			Summary: The time between checks in hours for GetEntitlementType check
+#		Core.LaunchResumeRetryPeriodSec
+#			Type: int
+#			Default: 15
+#			Info: Seconds Minimum=0
+#			Summary: Period after which users of the XML service are hinted to retry launches 
+#					 that are delayed due to a resume request just being sent to that VDA to 
+#					 satisfy launch.
+#		DBConnectionSettings.ResourceLimitRetryDelaySecs
+#			Type: int
+#			Default: 15
+#			Info: Seconds Minimum=2
+#			Summary: Interval between command batch retries when a resource limit appears to 
+#					 have been reached.
+#		HostingManagementSettings.MaxCompletedActionsToPurge
+#			Type: int
+#			Default: 700
+#			Info: Minimum=100
+#			Summary: Maximum completed power actions to purge in a single batch. This limit 
+#					 avoids timeouts/failures if for some reason huge numbers of actions have 
+#					 accumulated that need to be deleted.
+#
+#					 The default value allows for about 2 million actions to be purged per day 
+#					 if needed (700 every 30 seconds).
+#		LhcState.IsFirstConfigSyncSuccess
+#			Type: bool
+#			Default: false
+#			Info: 
+#			Summary: Indicates on the machine where the secondary broker resides that the 
+#					 secondary Broker successfully completed first config sync. An important 
+#					 function of this value is to ensure that if services are re-installed 
+#					 for any reason, the config sync ensures that we have the latest Lhc database.
+#		LhcState.LeaderInHAMode
+#			Type: bool
+#			Default: false
+#			Info: 
+#			Summary: Indicates whether the leader connector is in outage mode.
+#		NameCacheSettings.AlwaysRefreshNamesOnRegistration
+#			Type: bool
+#			Default: false
+#			Info: 
+#			Summary: Forces machine's cached name entries to be updated each time it registers. 
+#					 By default names are only updated by normal cache refresh logic.
+#		SiteServicesSettings.FeatureTelemetryCollectionPeriodSec
+#			Type: int
+#			Default: 21600
+#			Info: Seconds Minimum=1
+#			Summary: Period between instances of reporting of feature use.
+#		XmsSettings.NFuseAppDataBulkLookupThreshold
+#			Type: int
+#			Default: 2
+#			Info: Minimum=0
+#			Summary: Defines the threshold number of resources in an AppData transaction above 
+#					 which a bulk lookup mechanism is used. For small numbers of resources the 
+#					 higher setup cost outweighs the improved efficiency.
+#
+#	Added Computer policy
+#		ICA\HDX Direct
+#		Profile Management\Advanced settings\Free space ration (%)
+#		Profile Management\Advanced settings\Number of logoffs
+#		Profile Management\App access control
+#		Profile Management\Basic settings\Active write back on session lock and disconnection
+#		Profile Management\Profile container settings\Enable VHD disk compaction
+#		User Personalization Layer\User Layer Exclusions
+#	Added User policy
+#		ICA\File Redirection\Download file for Citrix Workspace app for Chrome OS/HTML5
+#		ICA\File Redirection\File transfer for Citrix Workspace app for Chrome OS/HTML5
+#		ICA\File Redirection\Upload file for Citrix Workspace app for Chrome OS/HTML5
+#	In Function GetRolePermissions:
+#		Added new permissions
+#			Director_Search_Transaction
+#			Image_Create        
+#			Image_Delete        
+#			Image_EditProperties
+#			Image_Read  
+#			SecureBrowser_NewConfiguration   
+#			SecureBrowser_Read               
+#			SecureBrowser_RemoveConfiguration
+#			SecureBrowser_SetConfiguration   
+#	In Function OutputDesktopOSMachine:
+#		test if there is a Desktop.DNSName
+#		If not, test Desktop.MachineName
+#		If not, test Desktop.HostedMachineName
+#		If not, use error message "error, there was no name found for the Desktop"
+#	In Function OutputHosting:
+#		update the list of Hypervisor Plugins
+#		for Word output:
+#			if there are no single-session OS or multi-session OS or sessions, output a message and don't waste a page
+#			add a page break after outputting Session data
+#	In Function OutputServerOSMachine:
+#		test if there is a Server.DNSName
+#		If not, test Server.MachineName
+#		If not, test Server.HostedMachineName
+#		If not, use error message "error, there was no name found for the Server"
+#	Tested with Group Policy Module 2303 dated March 20, 2023 
+#		(https://www.citrix.com/downloads/citrix-cloud/product-software/xenapp-and-xendesktop-service.html)
+#	Tested with PoSH SDK dated March 17, 2023 
+#		(https://download.apps.cloud.com/CitrixPoshSdk.exe)
+#	Updated for 7.37
+
+#Version 1.24
+#	Added Computer policy
+#		ICA\HDX Direct
+#		Profile Management\Advanced settings\Free space ration (%)
+#		Profile Management\Advanced settings\Number of logoffs
+#		Profile Management\App access control
+#		Profile Management\Basic settings\Active write back on session lock and disconnection
+#		Profile Management\Profile container settings\Enable VHD disk compaction
+#		User Personalization Layer\User Layer Exclusions
+#	Added User policy
+#		ICA\File Redirection\Download file for Citrix Workspace app for Chrome OS/HTML5
+#		ICA\File Redirection\File transfer for Citrix Workspace app for Chrome OS/HTML5
+#		ICA\File Redirection\Upload file for Citrix Workspace app for Chrome OS/HTML5
+
+
 #Version 1.23 6-Jan-2023
 #	Added to Function OutputMachines, the Catalog's reboot schedule if one exists
 #		https://docs.citrix.com/en-us/citrix-virtual-apps-desktops/install-configure/machine-catalogs-manage.html#update-the-catalog


### PR DESCRIPTION
#Version 1.24 24-Mar-2023
#	Added settings configurable by Set-BrokerServiceConfigurationData #		Core.GetEntitlementTypePeriodHours
#			Type: int
#			Default: 24
#			Info: Hours Minimum=1
#			Summary: The time between checks in hours for GetEntitlementType check #		Core.LaunchResumeRetryPeriodSec
#			Type: int
#			Default: 15
#			Info: Seconds Minimum=0
#			Summary: Period after which users of the XML service are hinted to retry launches  #					 that are delayed due to a resume request just being sent to that VDA to  #					 satisfy launch.
#		DBConnectionSettings.ResourceLimitRetryDelaySecs #			Type: int
#			Default: 15
#			Info: Seconds Minimum=2
#			Summary: Interval between command batch retries when a resource limit appears to  #					 have been reached.
#		HostingManagementSettings.MaxCompletedActionsToPurge #			Type: int
#			Default: 700
#			Info: Minimum=100
#			Summary: Maximum completed power actions to purge in a single batch. This limit  #					 avoids timeouts/failures if for some reason huge numbers of actions have  #					 accumulated that need to be deleted.
#
#					 The default value allows for about 2 million actions to be purged per day  #					 if needed (700 every 30 seconds).
#		LhcState.IsFirstConfigSyncSuccess
#			Type: bool
#			Default: false
#			Info: 
#			Summary: Indicates on the machine where the secondary broker resides that the  #					 secondary Broker successfully completed first config sync. An important  #					 function of this value is to ensure that if services are re-installed  #					 for any reason, the config sync ensures that we have the latest Lhc database. #		LhcState.LeaderInHAMode
#			Type: bool
#			Default: false
#			Info: 
#			Summary: Indicates whether the leader connector is in outage mode. #		NameCacheSettings.AlwaysRefreshNamesOnRegistration #			Type: bool
#			Default: false
#			Info: 
#			Summary: Forces machine's cached name entries to be updated each time it registers.  #					 By default names are only updated by normal cache refresh logic. #		SiteServicesSettings.FeatureTelemetryCollectionPeriodSec #			Type: int
#			Default: 21600
#			Info: Seconds Minimum=1
#			Summary: Period between instances of reporting of feature use. #		XmsSettings.NFuseAppDataBulkLookupThreshold
#			Type: int
#			Default: 2
#			Info: Minimum=0
#			Summary: Defines the threshold number of resources in an AppData transaction above  #					 which a bulk lookup mechanism is used. For small numbers of resources the  #					 higher setup cost outweighs the improved efficiency. #
#	Added Computer policy
#		ICA\HDX Direct
#		Profile Management\Advanced settings\Free space ration (%) #		Profile Management\Advanced settings\Number of logoffs #		Profile Management\App access control
#		Profile Management\Basic settings\Active write back on session lock and disconnection #		Profile Management\Profile container settings\Enable VHD disk compaction #		User Personalization Layer\User Layer Exclusions #	Added User policy
#		ICA\File Redirection\Download file for Citrix Workspace app for Chrome OS/HTML5 #		ICA\File Redirection\File transfer for Citrix Workspace app for Chrome OS/HTML5 #		ICA\File Redirection\Upload file for Citrix Workspace app for Chrome OS/HTML5 #	In Function GetRolePermissions:
#		Added new permissions
#			Director_Search_Transaction
#			Image_Create        
#			Image_Delete        
#			Image_EditProperties
#			Image_Read  
#			SecureBrowser_NewConfiguration   
#			SecureBrowser_Read               
#			SecureBrowser_RemoveConfiguration
#			SecureBrowser_SetConfiguration   
#	In Function OutputDesktopOSMachine:
#		test if there is a Desktop.DNSName
#		If not, test Desktop.MachineName
#		If not, test Desktop.HostedMachineName
#		If not, use error message "error, there was no name found for the Desktop" #	In Function OutputHosting:
#		update the list of Hypervisor Plugins
#		for Word output:
#			if there are no single-session OS or multi-session OS or sessions, output a message and don't waste a page #			add a page break after outputting Session data #	In Function OutputServerOSMachine:
#		test if there is a Server.DNSName
#		If not, test Server.MachineName
#		If not, test Server.HostedMachineName
#		If not, use error message "error, there was no name found for the Server" #	Tested with Group Policy Module 2303 dated March 20, 2023  #		(https://www.citrix.com/downloads/citrix-cloud/product-software/xenapp-and-xendesktop-service.html) #	Tested with PoSH SDK dated March 17, 2023 
#		(https://download.apps.cloud.com/CitrixPoshSdk.exe) #	Updated for 7.37